### PR TITLE
Fixed page change listener not calling

### DIFF
--- a/ultraviewpager/src/main/java/com/tmall/ultraviewpager/UltraViewPager.java
+++ b/ultraviewpager/src/main/java/com/tmall/ultraviewpager/UltraViewPager.java
@@ -395,7 +395,7 @@ public class UltraViewPager extends RelativeLayout implements IUltraViewPagerFea
 
     public void setOnPageChangeListener(ViewPager.OnPageChangeListener listener) {
         if (pagerIndicator == null) {
-            viewPager.setOnPageChangeListener(listener);
+            viewPager.addOnPageChangeListener(listener);
         } else {
             pagerIndicator.setPageChangeListener(listener);
         }


### PR DESCRIPTION
The deprecated setOnPageChangeListener wasn't callling on page changes. Updating to the new addOnPageChangeListener method fixed the issue.