### PR TITLE
修改改变数据源时导致的异常

### DIFF
--- a/ultraviewpager/src/main/java/com/tmall/ultraviewpager/UltraViewPager.java
+++ b/ultraviewpager/src/main/java/com/tmall/ultraviewpager/UltraViewPager.java
@@ -352,6 +352,7 @@ public class UltraViewPager extends RelativeLayout implements IUltraViewPagerFea
     @Override
     public void scrollNextPage() {
         if (viewPager != null && viewPager.getAdapter() != null && viewPager.getAdapter().getCount() > 0) {
+        	viewPager.getAdapter().notifyDataSetChanged();
             final int curr = viewPager.getCurrentItemFake();
             int nextPage = 0;
             if (curr < viewPager.getAdapter().getCount() - 1) {


### PR DESCRIPTION
https://github.com/alibaba/UltraViewPager/issues/36
https://github.com/alibaba/UltraViewPager/issues/37

demo中的数据源因为是写死的，所以不会出现这个异常
```
RequestServerTask: java.lang.IllegalStateException: The application's PagerAdapter changed the adapter's contents without calling PagerAdapter#notifyDataSetChanged! Expected adapter item count: 800, found: 2000 Pager id: 2 Pager class: class com.tmall.ultraviewpager.UltraViewPagerView Problematic adapter: class com.tmall.ultraviewpager.UltraViewPagerAdapter
```

原因是外面包裹的UltraViewPagerAdapter，重写的getCount()
有个if导致返回的count *400 ，但是此时数据更新的dataSetChanged 还没有被调用， `mExpectedAdapterCount` 也没有被赋值，所以发生了`N != mExpectedAdapterCount`

我在`scrollNextPage()` 方法中刷新一下数据`viewPager.getAdapter().notifyDataSetChanged();` 
，这样就不会产生了`N != mExpectedAdapterCount ` 了。
我觉得这样有性能问题，但是以我的能力只能暂时这样解决。希望@MikeAfc 大大可以帮忙解决一下